### PR TITLE
Read topicsPattern from env variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl.transitdata</groupId>
     <artifactId>transitdata-tripupdate-processor</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <packaging>jar</packaging>
 
     <repositories>
@@ -18,7 +18,7 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <pulsar.version>2.1.0-incubating</pulsar.version>
-        <common.version>0.1.3</common.version>
+        <common.version>0.2.0</common.version>
     </properties>
 
     <dependencies>

--- a/src/main/resources/environment.conf
+++ b/src/main/resources/environment.conf
@@ -4,7 +4,7 @@ pulsar {
   consumer {
     multipleTopics=true
     multipleTopics=${?PULSAR_CONSUMER_ENABLE_MULTIPLE_TOPICS}
-    topicsPattern="ptroi-(arrival|departure)"
+    topicsPattern="persistent://public/default/ptroi-(arrival|departure)"
     topicsPattern=${?PULSAR_CONSUMER_MULTIPLE_TOPICS_PATTERN}
 
     subscription="trip-update-subscription"

--- a/src/main/resources/environment.conf
+++ b/src/main/resources/environment.conf
@@ -2,14 +2,17 @@ include "common.conf"
 
 pulsar {
   consumer {
-    #topic="stop-time-update"
     multipleTopics=true
-    topics=["ptroi-arrival", "ptroi-departure"]
+    multipleTopics=${?PULSAR_CONSUMER_ENABLE_MULTIPLE_TOPICS}
+    topicsPattern="ptroi-(arrival|departure)"
+    topicsPattern=${?PULSAR_CONSUMER_MULTIPLE_TOPICS_PATTERN}
 
     subscription="trip-update-subscription"
+    subscription=${?PULSAR_CONSUMER_SUBSCRIPTION}
   }
   producer {
     topic="trip-update"
+    topic=${?PULSAR_PRODUCER_TOPIC}
   }
 }
 


### PR DESCRIPTION
commons 0.2.0 allows the use of topicsPattern which we can read from env variables.

Requires merging of this https://github.com/HSLdevcom/transitdata-common/pull/35

and also publishing the new version to bintray.