### PR TITLE
Bug/tripupdate cache key

### DIFF
--- a/src/main/java/fi/hsl/transitdata/tripupdate/GtfsRtFactory.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/GtfsRtFactory.java
@@ -2,8 +2,8 @@ package fi.hsl.transitdata.tripupdate;
 
 import com.google.transit.realtime.GtfsRealtime;
 
-public class GtfsFactory {
-    private GtfsFactory() {}
+public class GtfsRtFactory {
+    private GtfsRtFactory() {}
 
 
     public static GtfsRealtime.FeedMessage newFeedMessage(String id, GtfsRealtime.TripUpdate tripUpdate, long timestamp) {

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Logger name="fi.hsl" level="trace" additivity="false">
+        <Logger name="fi.hsl" level="info" additivity="false">
             <AppenderRef ref="STDOUT" />
         </Logger>
         <Root level="error">


### PR DESCRIPTION
use dvjId as cache key, not pulsar message id.

fixes https://github.com/HSLdevcom/transitdata-tripupdate-processor/issues/2

also improved logging and variable naming.