### PR TITLE
Feat/modify route ids

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl.transitdata</groupId>
     <artifactId>transitdata-tripupdate-processor</artifactId>
-    <version>0.4.1</version>
+    <version>0.4.2</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/src/main/java/fi/hsl/transitdata/tripupdate/processing/BaseProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/processing/BaseProcessor.java
@@ -89,6 +89,10 @@ public abstract class BaseProcessor implements IMessageProcessor {
             }
         }
 
+        if (!ProcessorUtils.validateRouteName(properties.get(TransitdataProperties.KEY_ROUTE_NAME))) {
+            return false;
+        }
+
         //Filter out trains. Currently route IDs for trains are 3001 and 3002.
         Pattern trainPattern = Pattern.compile("^300(1|2)");
         if (trainPattern.matcher(properties.get(TransitdataProperties.KEY_ROUTE_NAME)).find()) {

--- a/src/main/java/fi/hsl/transitdata/tripupdate/processing/ProcessorUtils.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/processing/ProcessorUtils.java
@@ -1,0 +1,17 @@
+package fi.hsl.transitdata.tripupdate.processing;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ProcessorUtils {
+
+    static final String JORE_ROUTE_NAME_REGEX = "^\\d{4}([a-zA-Z]{1}[a-zA-Z0-9]{0,1}$|[a-zA-Z ]{1}\\d{1}$|$)";
+
+    static boolean validateRouteName(String routeName) {
+
+        Pattern routePattern = Pattern.compile(JORE_ROUTE_NAME_REGEX);
+        Matcher matcher = routePattern.matcher(routeName);
+
+        return matcher.matches();
+    }
+}

--- a/src/main/java/fi/hsl/transitdata/tripupdate/processing/TripCancellationProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/processing/TripCancellationProcessor.java
@@ -26,7 +26,7 @@ public class TripCancellationProcessor implements IMessageProcessor {
 
             if (tripCancellation.hasDirectionId() && tripCancellation.hasRouteId() &&
                 tripCancellation.hasStartDate() && tripCancellation.hasStartTime()) {
-                return true;
+                return ProcessorUtils.validateRouteName(tripCancellation.getRouteId());
             }
 
         } catch (InvalidProtocolBufferException e) {
@@ -52,4 +52,5 @@ public class TripCancellationProcessor implements IMessageProcessor {
         return tripUpdate;
 
     }
+
 }

--- a/src/test/java/fi/hsl/transitdata/tripupdate/MockDataFactory.java
+++ b/src/test/java/fi/hsl/transitdata/tripupdate/MockDataFactory.java
@@ -2,6 +2,7 @@ package fi.hsl.transitdata.tripupdate;
 
 import com.google.transit.realtime.GtfsRealtime;
 import fi.hsl.common.transitdata.TransitdataProperties;
+import fi.hsl.common.transitdata.proto.InternalMessages;
 import fi.hsl.common.transitdata.proto.PubtransTableProtos;
 import fi.hsl.transitdata.tripupdate.gtfsrt.GtfsRtFactory;
 import fi.hsl.transitdata.tripupdate.models.StopEvent;
@@ -56,6 +57,15 @@ public class MockDataFactory {
 
         Map<String, String> props = mockMessageProperties(stopId, GtfsRtFactory.DIRECTION_ID_INBOUND, "route-name", dateAndTime[0], dateAndTime[1]);
         return StopEvent.newInstance(common, props, eventType);
+    }
+
+    public static StopEvent mockStopEvent(String routeId) {
+
+        Map<String, String> mockProperties = mockMessageProperties(1234567, 0, routeId, "20180101", "11:22:00");
+
+        PubtransTableProtos.Common mockCommon = mockCommon(111, 2, 333);
+
+        return StopEvent.newInstance(mockCommon, mockProperties, StopEvent.EventType.Arrival);
     }
 
 
@@ -116,6 +126,25 @@ public class MockDataFactory {
         }
 
         return stopTimeUpdateBuilder.setStopId(stopId).build();
+    }
+
+    public static InternalMessages.TripCancellation mockTripCancellation(String routeId, int directionId,
+                                                                         String startDate, String startTime) {
+
+        InternalMessages.TripCancellation.Builder tripCancellationBuilder = InternalMessages.TripCancellation.newBuilder();
+
+        tripCancellationBuilder.setRouteId(routeId)
+                .setDirectionId(directionId)
+                .setStartDate(startDate)
+                .setStartTime(startTime)
+                .setSchemaVersion(tripCancellationBuilder.getSchemaVersion())
+                .setStatus(InternalMessages.TripCancellation.Status.CANCELED);
+
+        return tripCancellationBuilder.build();
+    }
+
+    public static InternalMessages.TripCancellation mockTripCancellation(String routeId) {
+        return mockTripCancellation(routeId, 0, "20180101", "11:22:00");
     }
 
     public static GtfsRealtime.TripUpdate mockTripUpdate(String routeId, int directionId,

--- a/src/test/java/fi/hsl/transitdata/tripupdate/gtfsrt/GtfsRtFactoryTest.java
+++ b/src/test/java/fi/hsl/transitdata/tripupdate/gtfsrt/GtfsRtFactoryTest.java
@@ -1,0 +1,102 @@
+package fi.hsl.transitdata.tripupdate.gtfsrt;
+
+import com.google.transit.realtime.GtfsRealtime;
+import fi.hsl.common.transitdata.proto.InternalMessages;
+import fi.hsl.transitdata.tripupdate.MockDataFactory;
+import fi.hsl.transitdata.tripupdate.models.StopEvent;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class GtfsRtFactoryTest {
+
+    @Test
+    public void newTripUpdateFromStopEventWithLetterAndNumberIsRenamedProperly() {
+
+        StopEvent stopEvent = MockDataFactory.mockStopEvent("1010H4");
+        GtfsRealtime.TripUpdate tripUpdate = GtfsRtFactory.newTripUpdate(stopEvent);
+
+        assertEquals("1010H", tripUpdate.getTrip().getRouteId());
+    }
+
+    @Test
+    public void newTripUpdateFromStopEventWithSpaceAndNumberIsRenamedProperly() {
+
+        StopEvent stopEvent = MockDataFactory.mockStopEvent("1010 3");
+        GtfsRealtime.TripUpdate tripUpdate = GtfsRtFactory.newTripUpdate(stopEvent);
+
+        assertEquals("1010", tripUpdate.getTrip().getRouteId());
+    }
+
+    @Test
+    public void newTripUpdateFromStopEventWithFourCharactersIsNotRenamed() {
+
+        StopEvent stopEvent = MockDataFactory.mockStopEvent("1010");
+        GtfsRealtime.TripUpdate tripUpdate = GtfsRtFactory.newTripUpdate(stopEvent);
+
+        assertEquals("1010", tripUpdate.getTrip().getRouteId());
+    }
+
+    @Test
+    public void newTripUpdateFromStopEventWithOneLetterIsNotRenamed() {
+
+        StopEvent stopEvent = MockDataFactory.mockStopEvent("1010H");
+        GtfsRealtime.TripUpdate tripUpdate = GtfsRtFactory.newTripUpdate(stopEvent);
+
+        assertEquals("1010H", tripUpdate.getTrip().getRouteId());
+    }
+
+    @Test
+    public void newTripUpdateFromStopEventWithTwoLettersIsNotRenamed() {
+
+        StopEvent stopEvent = MockDataFactory.mockStopEvent("1010HK");
+        GtfsRealtime.TripUpdate tripUpdate = GtfsRtFactory.newTripUpdate(stopEvent);
+
+        assertEquals("1010HK", tripUpdate.getTrip().getRouteId());
+    }
+
+    @Test
+    public void newTripUpdateFromTripCancellationWithLetterAndNumberIsRenamedProperly() {
+
+        InternalMessages.TripCancellation tripCancellation = MockDataFactory.mockTripCancellation("1010H4");
+        GtfsRealtime.TripUpdate tripUpdate = GtfsRtFactory.newTripUpdate(tripCancellation, 1542096708);
+
+        assertEquals("1010H", tripUpdate.getTrip().getRouteId());
+    }
+
+    @Test
+    public void newTripUpdateFromTripCancellationWithSpaceAndNumberIsRenamedProperly() {
+
+        InternalMessages.TripCancellation tripCancellation = MockDataFactory.mockTripCancellation("1010 3");
+        GtfsRealtime.TripUpdate tripUpdate = GtfsRtFactory.newTripUpdate(tripCancellation, 1542096708);
+
+        assertEquals("1010", tripUpdate.getTrip().getRouteId());
+    }
+
+    @Test
+    public void newTripUpdateFromTripCancellationWithFourCharactersIsNotRenamed() {
+
+        InternalMessages.TripCancellation tripCancellation = MockDataFactory.mockTripCancellation("1010");
+        GtfsRealtime.TripUpdate tripUpdate = GtfsRtFactory.newTripUpdate(tripCancellation, 1542096708);
+
+        assertEquals("1010", tripUpdate.getTrip().getRouteId());
+    }
+
+    @Test
+    public void newTripUpdateFromTripCancellationWithOneLetterIsNotRenamed() {
+
+        InternalMessages.TripCancellation tripCancellation = MockDataFactory.mockTripCancellation("1010H");
+        GtfsRealtime.TripUpdate tripUpdate = GtfsRtFactory.newTripUpdate(tripCancellation, 1542096708);
+
+        assertEquals("1010H", tripUpdate.getTrip().getRouteId());
+    }
+
+    @Test
+    public void newTripUpdateFromTripCancellationWithTwoLettersIsNotRenamed() {
+
+        InternalMessages.TripCancellation tripCancellation = MockDataFactory.mockTripCancellation("1010HK");
+        GtfsRealtime.TripUpdate tripUpdate = GtfsRtFactory.newTripUpdate(tripCancellation, 1542096708);
+
+        assertEquals("1010HK", tripUpdate.getTrip().getRouteId());
+    }
+}

--- a/src/test/java/fi/hsl/transitdata/tripupdate/processing/ProcessorUtilsTest.java
+++ b/src/test/java/fi/hsl/transitdata/tripupdate/processing/ProcessorUtilsTest.java
@@ -1,0 +1,59 @@
+package fi.hsl.transitdata.tripupdate.processing;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ProcessorUtilsTest {
+
+    @Test
+    public void routeNameWithNoVariantsIsValid() {
+        assertEquals(true, ProcessorUtils.validateRouteName("1014"));
+    }
+
+    @Test
+    public void routeNameWithOneLetterIsValid() {
+        assertEquals(true, ProcessorUtils.validateRouteName("6173K"));
+    }
+
+    @Test
+    public void routeNameWithTwoLettersIsValid() {
+        assertEquals(true, ProcessorUtils.validateRouteName("9785AK"));
+    }
+
+    @Test
+    public void routeNameWithLetterAndNumberIsValid() {
+        assertEquals(true, ProcessorUtils.validateRouteName("3100M2"));
+    }
+
+    @Test
+    public void routeNameWithSpaceAndNumberIsValid() {
+        assertEquals(true, ProcessorUtils.validateRouteName("1010 4"));
+    }
+
+    @Test
+    public void routeNameWithTwoSpacesIsInvalid() {
+        assertEquals(false, ProcessorUtils.validateRouteName("1010  4"));
+    }
+
+    @Test
+    public void routeNameWithTrailingSpaceIsInvalid() {
+        assertEquals(false, ProcessorUtils.validateRouteName("1010 "));
+    }
+
+    @Test
+    public void routeNameWithTwoTrailingSpacesIsInvalid() {
+        assertEquals(false, ProcessorUtils.validateRouteName("1010  "));
+    }
+
+    @Test
+    public void routeNameWithLettersInBeginningIsInvalid() {
+        assertEquals(false, ProcessorUtils.validateRouteName("M100"));
+    }
+
+    @Test
+    public void routeNameLongerThanSixCharsIsInvalid() {
+        assertEquals(false, ProcessorUtils.validateRouteName("6173AKT"));
+    }
+
+}


### PR DESCRIPTION
Issue: https://github.com/HSLdevcom/transitdata-tripupdate-processor/issues/7

Add functionality to remove trailing numbers from route ids. Also includes unit tests for all the different variations and some methods for generating mock data.