### PR TITLE
Finetuned logging levels to prevent false alarms.

### DIFF
--- a/src/main/java/fi/hsl/transitdata/tripupdate/application/MessageRouter.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/application/MessageRouter.java
@@ -96,7 +96,7 @@ public class MessageRouter implements IMessageHandler {
                         }
                     }
                     else {
-                        log.warn("Errors with message payload, ignoring.");
+                        log.info("Message didn't pass validation, ignoring.");
                     }
                 }
                 else {

--- a/src/main/java/fi/hsl/transitdata/tripupdate/processing/BaseProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/processing/BaseProcessor.java
@@ -116,7 +116,7 @@ public abstract class BaseProcessor implements IMessageProcessor {
             return false;
         }
         if (common.getType() == 0) {
-            log.error("Event is for a via point, message discarded");
+            log.info("Event is for a via point, message discarded");
             return false;
         }
         return true;

--- a/src/main/java/fi/hsl/transitdata/tripupdate/processing/BaseProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/processing/BaseProcessor.java
@@ -89,13 +89,14 @@ public abstract class BaseProcessor implements IMessageProcessor {
             }
         }
 
-        if (!ProcessorUtils.validateRouteName(properties.get(TransitdataProperties.KEY_ROUTE_NAME))) {
+        final String routeName = properties.get(TransitdataProperties.KEY_ROUTE_NAME);
+        if (!ProcessorUtils.validateRouteName(routeName)) {
+            log.warn("Invalid route name {}, discarding message", routeName);
             return false;
         }
 
-        //Filter out trains. Currently route IDs for trains are 3001 and 3002.
-        Pattern trainPattern = Pattern.compile("^300(1|2)");
-        if (trainPattern.matcher(properties.get(TransitdataProperties.KEY_ROUTE_NAME)).find()) {
+        if (ProcessorUtils.isTrainRoute(routeName)) {
+            log.info("Route {} is for trains, discarding message", routeName);
             return false;
         }
 

--- a/src/main/java/fi/hsl/transitdata/tripupdate/processing/ProcessorUtils.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/processing/ProcessorUtils.java
@@ -1,17 +1,27 @@
 package fi.hsl.transitdata.tripupdate.processing;
 
+import fi.hsl.common.transitdata.TransitdataProperties;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ProcessorUtils {
 
     static final String JORE_ROUTE_NAME_REGEX = "^\\d{4}([a-zA-Z]{1}[a-zA-Z0-9]{0,1}$|[a-zA-Z ]{1}\\d{1}$|$)";
+    static final Pattern JORE_ROUTE_PATTERN = Pattern.compile(JORE_ROUTE_NAME_REGEX);
+
+    // Currently route IDs for trains are 3001 and 3002.
+    static final String TRAIN_ROUTE_NAME_REGEX = "^300(1|2)";
+    static final Pattern TRAIN_ROUTE_PATTERN = Pattern.compile(TRAIN_ROUTE_NAME_REGEX);
+
 
     static boolean validateRouteName(String routeName) {
-
-        Pattern routePattern = Pattern.compile(JORE_ROUTE_NAME_REGEX);
-        Matcher matcher = routePattern.matcher(routeName);
-
+        Matcher matcher = JORE_ROUTE_PATTERN.matcher(routeName);
         return matcher.matches();
+    }
+
+    static boolean isTrainRoute(String routeName) {
+        Matcher matcher = TRAIN_ROUTE_PATTERN.matcher(routeName);
+        return matcher.find();
     }
 }

--- a/src/test/java/fi/hsl/transitdata/tripupdate/processing/ProcessorUtilsTest.java
+++ b/src/test/java/fi/hsl/transitdata/tripupdate/processing/ProcessorUtilsTest.java
@@ -1,8 +1,14 @@
 package fi.hsl.transitdata.tripupdate.processing;
 
+import fi.hsl.common.transitdata.TransitdataProperties;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ProcessorUtilsTest {
 
@@ -54,6 +60,25 @@ public class ProcessorUtilsTest {
     @Test
     public void routeNameLongerThanSixCharsIsInvalid() {
         assertEquals(false, ProcessorUtils.validateRouteName("6173AKT"));
+    }
+
+    @Test
+    public void trainRouteMatches() {
+        assertTrue(ProcessorUtils.isTrainRoute("3001K"));
+        assertTrue(ProcessorUtils.isTrainRoute("3002U"));
+        assertTrue(ProcessorUtils.isTrainRoute("3001"));
+        assertTrue(ProcessorUtils.isTrainRoute("3002"));
+        assertTrue(ProcessorUtils.isTrainRoute("3002 ABC"));
+    }
+
+    @Test
+    public void nonTrainRoutesDoesntMatch() {
+        assertFalse(ProcessorUtils.isTrainRoute("3000K"));
+        assertFalse(ProcessorUtils.isTrainRoute("3003U"));
+        assertFalse(ProcessorUtils.isTrainRoute("3000"));
+        assertFalse(ProcessorUtils.isTrainRoute("3003"));
+        assertFalse(ProcessorUtils.isTrainRoute("757"));
+        assertFalse(ProcessorUtils.isTrainRoute("30002"));
     }
 
 }


### PR DESCRIPTION
I went through the logging levels and I feel that after this we can setup automatic alerts for all [error]-level logging. 

also fixes https://github.com/HSLdevcom/transitdata-tripupdate-processor/issues/18
