### PR TITLE
Feat/read cancellation tripid from payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <pulsar.version>2.1.0-incubating</pulsar.version>
-        <common.version>0.8.1</common.version>
+        <common.version>0.8.3</common.version>
         <testcontainers.version>1.9.0</testcontainers.version>
     </properties>
     <profiles>

--- a/src/integration-test/java/fi/hsl/transitdata/tripupdate/application/ITTripUpdateProcessor.java
+++ b/src/integration-test/java/fi/hsl/transitdata/tripupdate/application/ITTripUpdateProcessor.java
@@ -65,7 +65,7 @@ public class ITTripUpdateProcessor extends ITBaseTestSuite {
             @Override
             public void testImpl(TestPipeline.TestContext context) throws Exception {
                 final long ts = System.currentTimeMillis();
-                InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(routeName, joreDir, dateTime);
+                InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(routeName, joreDir, dateTime, Long.toString(dvjId));
                 sendPubtransSourcePulsarMessage(context.source, new PubtransPulsarMessageData.CancellationPulsarMessageData(cancellation, ts, dvjId));
                 logger.info("Message sent, reading it back");
 
@@ -90,7 +90,7 @@ public class ITTripUpdateProcessor extends ITBaseTestSuite {
     public void testCancellationWithGtfsRtDirection() throws Exception {
         //InternalMessages are in Jore format 1-2, gtfs-rt in 0-1
         final int invalidJoreDirection = 0;
-        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(route, invalidJoreDirection, dateTime);
+        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(route, invalidJoreDirection, dateTime, Long.toString(dvjId));
         PubtransPulsarMessageData data = new PubtransPulsarMessageData.CancellationPulsarMessageData(cancellation, System.currentTimeMillis(), dvjId);
 
         testInvalidInput(data, "-test-gtfs-dir");
@@ -99,7 +99,7 @@ public class ITTripUpdateProcessor extends ITBaseTestSuite {
     @Test
     public void testCancellationWithInvalidDirection() throws Exception {
         //InternalMessages are in Jore format 1-2, gtfs-rt in 0-1
-        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(route, 10, dateTime);
+        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(route, 10, dateTime, Long.toString(dvjId));
         PubtransPulsarMessageData data = new PubtransPulsarMessageData.CancellationPulsarMessageData(cancellation, System.currentTimeMillis(), dvjId);
         testInvalidInput(data, "-test-invalid-dir");
     }
@@ -107,7 +107,7 @@ public class ITTripUpdateProcessor extends ITBaseTestSuite {
     @Test
     public void testCancellationWithRunningStatus() throws Exception {
         final InternalMessages.TripCancellation.Status runningStatus = InternalMessages.TripCancellation.Status.RUNNING;
-        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(route, 10, dateTime, runningStatus);
+        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(route, 10, dateTime, runningStatus, Long.toString(dvjId));
         PubtransPulsarMessageData data = new PubtransPulsarMessageData.CancellationPulsarMessageData(cancellation, System.currentTimeMillis(), dvjId);
         testInvalidInput(data, "-test-running");
     }
@@ -115,7 +115,7 @@ public class ITTripUpdateProcessor extends ITBaseTestSuite {
     @Test
     public void testCancellationWithTrainRoute() throws Exception {
         String trainRoute = "3001";
-        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(trainRoute, joreDirection, dateTime);
+        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(trainRoute, joreDirection, dateTime, Long.toString(dvjId));
         PubtransPulsarMessageData data = new PubtransPulsarMessageData.CancellationPulsarMessageData(cancellation, System.currentTimeMillis(), dvjId);
         testInvalidInput(data, "-test-train-route");
     }

--- a/src/integration-test/java/fi/hsl/transitdata/tripupdate/application/ITTripUpdateProcessor.java
+++ b/src/integration-test/java/fi/hsl/transitdata/tripupdate/application/ITTripUpdateProcessor.java
@@ -65,7 +65,7 @@ public class ITTripUpdateProcessor extends ITBaseTestSuite {
             @Override
             public void testImpl(TestPipeline.TestContext context) throws Exception {
                 final long ts = System.currentTimeMillis();
-                InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(routeName, joreDir, dateTime, Long.toString(dvjId));
+                InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(dvjId, routeName, joreDir, dateTime);
                 sendPubtransSourcePulsarMessage(context.source, new PubtransPulsarMessageData.CancellationPulsarMessageData(cancellation, ts, dvjId));
                 logger.info("Message sent, reading it back");
 
@@ -90,7 +90,7 @@ public class ITTripUpdateProcessor extends ITBaseTestSuite {
     public void testCancellationWithGtfsRtDirection() throws Exception {
         //InternalMessages are in Jore format 1-2, gtfs-rt in 0-1
         final int invalidJoreDirection = 0;
-        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(route, invalidJoreDirection, dateTime, Long.toString(dvjId));
+        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(dvjId, route, invalidJoreDirection, dateTime);
         PubtransPulsarMessageData data = new PubtransPulsarMessageData.CancellationPulsarMessageData(cancellation, System.currentTimeMillis(), dvjId);
 
         testInvalidInput(data, "-test-gtfs-dir");
@@ -99,7 +99,7 @@ public class ITTripUpdateProcessor extends ITBaseTestSuite {
     @Test
     public void testCancellationWithInvalidDirection() throws Exception {
         //InternalMessages are in Jore format 1-2, gtfs-rt in 0-1
-        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(route, 10, dateTime, Long.toString(dvjId));
+        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(dvjId, route, 10, dateTime);
         PubtransPulsarMessageData data = new PubtransPulsarMessageData.CancellationPulsarMessageData(cancellation, System.currentTimeMillis(), dvjId);
         testInvalidInput(data, "-test-invalid-dir");
     }
@@ -107,7 +107,7 @@ public class ITTripUpdateProcessor extends ITBaseTestSuite {
     @Test
     public void testCancellationWithRunningStatus() throws Exception {
         final InternalMessages.TripCancellation.Status runningStatus = InternalMessages.TripCancellation.Status.RUNNING;
-        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(route, 10, dateTime, runningStatus, Long.toString(dvjId));
+        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(dvjId, route, 10, dateTime, runningStatus);
         PubtransPulsarMessageData data = new PubtransPulsarMessageData.CancellationPulsarMessageData(cancellation, System.currentTimeMillis(), dvjId);
         testInvalidInput(data, "-test-running");
     }
@@ -115,7 +115,7 @@ public class ITTripUpdateProcessor extends ITBaseTestSuite {
     @Test
     public void testCancellationWithTrainRoute() throws Exception {
         String trainRoute = "3001";
-        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(trainRoute, joreDirection, dateTime, Long.toString(dvjId));
+        InternalMessages.TripCancellation cancellation = MockDataUtils.mockTripCancellation(dvjId, trainRoute, joreDirection, dateTime);
         PubtransPulsarMessageData data = new PubtransPulsarMessageData.CancellationPulsarMessageData(cancellation, System.currentTimeMillis(), dvjId);
         testInvalidInput(data, "-test-train-route");
     }

--- a/src/main/java/fi/hsl/transitdata/tripupdate/application/IMessageProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/application/IMessageProcessor.java
@@ -3,6 +3,8 @@ package fi.hsl.transitdata.tripupdate.application;
 import com.google.transit.realtime.GtfsRealtime;
 import org.apache.pulsar.client.api.Message;
 
+import java.util.Optional;
+
 public interface IMessageProcessor {
     /**
      * Check the data within the payload
@@ -16,5 +18,5 @@ public interface IMessageProcessor {
      * Invoked if message goes through the validation
      * @param msg
      */
-    GtfsRealtime.TripUpdate processMessage(Message msg);
+    Optional<GtfsRealtime.TripUpdate> processMessage(Message msg);
 }

--- a/src/main/java/fi/hsl/transitdata/tripupdate/processing/BaseProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/processing/BaseProcessor.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Optional;
 
 public abstract class BaseProcessor implements IMessageProcessor {
     protected static final Logger log = LoggerFactory.getLogger(BaseProcessor.class);
@@ -34,21 +35,15 @@ public abstract class BaseProcessor implements IMessageProcessor {
     protected abstract PubtransData parseSharedData(Message msg) throws InvalidProtocolBufferException;
 
     @Override
-    public GtfsRealtime.TripUpdate processMessage(Message msg) {
-
-        GtfsRealtime.TripUpdate tripUpdate = null;
-
+    public Optional<GtfsRealtime.TripUpdate> processMessage(Message msg) {
         try {
             PubtransData data = parseSharedData(msg);
-
-            // Create TripUpdate and send it out
-            tripUpdate = tripProcessor.processStopEstimate(data.toStopEstimate());
+            return  tripProcessor.processStopEstimate(data.toStopEstimate());
         }
         catch (Exception e) {
             log.error("Failed to parse message payload", e);
+            return Optional.empty();
         }
-
-        return tripUpdate;
     }
 
     @Override

--- a/src/main/java/fi/hsl/transitdata/tripupdate/processing/TripCancellationProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/processing/TripCancellationProcessor.java
@@ -51,7 +51,7 @@ public class TripCancellationProcessor implements IMessageProcessor {
 
         try {
             InternalMessages.TripCancellation tripCancellation = InternalMessages.TripCancellation.parseFrom(msg.getData());
-            tripUpdate = tripUpdateProcessor.processTripCancellation(msg.getKey(), msg.getEventTime(), tripCancellation);
+            tripUpdate = tripUpdateProcessor.processTripCancellation(msg.getEventTime(), tripCancellation);
         } catch (Exception e) {
             log.error("Could not parse TripCancellation: " + e.getMessage(), e);
         }

--- a/src/main/java/fi/hsl/transitdata/tripupdate/processing/TripCancellationProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/processing/TripCancellationProcessor.java
@@ -8,6 +8,8 @@ import org.apache.pulsar.client.api.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Optional;
+
 public class TripCancellationProcessor implements IMessageProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(TripCancellationProcessor.class);
@@ -45,19 +47,14 @@ public class TripCancellationProcessor implements IMessageProcessor {
     }
 
     @Override
-    public GtfsRealtime.TripUpdate processMessage(Message msg) {
-
-        GtfsRealtime.TripUpdate tripUpdate = null;
-
+    public Optional<GtfsRealtime.TripUpdate> processMessage(Message msg) {
         try {
             InternalMessages.TripCancellation tripCancellation = InternalMessages.TripCancellation.parseFrom(msg.getData());
-            tripUpdate = tripUpdateProcessor.processTripCancellation(msg.getEventTime(), tripCancellation);
+            return tripUpdateProcessor.processTripCancellation(msg.getEventTime(), tripCancellation);
         } catch (Exception e) {
             log.error("Could not parse TripCancellation: " + e.getMessage(), e);
+            return Optional.empty();
         }
-
-        return tripUpdate;
-
     }
 
 }

--- a/src/main/java/fi/hsl/transitdata/tripupdate/processing/TripUpdateProcessor.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/processing/TripUpdateProcessor.java
@@ -47,7 +47,7 @@ public class TripUpdateProcessor {
                 });
     }
 
-    public TripUpdate processStopEstimate(InternalMessages.StopEstimate stopEstimate) {
+    public Optional<TripUpdate> processStopEstimate(InternalMessages.StopEstimate stopEstimate) {
         TripUpdate tripUpdate = null;
         try {
             final StopTimeUpdate latest = updateStopTimeUpdateCache(stopEstimate);
@@ -63,12 +63,12 @@ public class TripUpdateProcessor {
             log.error("Exception while translating StopEstimate into TripUpdate", e);
         }
 
-        return tripUpdate;
+        return Optional.ofNullable(tripUpdate);
 
     }
 
 
-    public TripUpdate processTripCancellation(long messageTimestamp, InternalMessages.TripCancellation tripCancellation) {
+    public Optional<TripUpdate> processTripCancellation(long messageTimestamp, InternalMessages.TripCancellation tripCancellation) {
         TripUpdate tripUpdate = null;
 
         if (tripCancellation.getStatus() == InternalMessages.TripCancellation.Status.CANCELED) {
@@ -91,7 +91,7 @@ public class TripUpdateProcessor {
             log.error("Unknown Trip Cancellation Status: " + tripCancellation.getStatus());
         }
 
-        return tripUpdate;
+        return Optional.ofNullable(tripUpdate);
     }
 
     private String cacheKey(final InternalMessages.StopEstimate stopEstimate) {


### PR DESCRIPTION
fixes https://github.com/HSLdevcom/transitdata-tripupdate-processor/issues/46

also improves error handling. currently cancellation-messages with unexpected content can crash the whole app. 

requires merging and deploying corresponding changes to omm-cancellation-source and hslalert-source

requires also release of [commons 0.8.3](https://github.com/HSLdevcom/transitdata-common/pull/69), test data generation is missing the field.