### PR TITLE
Enable cancellation of cancellation by reading TripCancellation statu…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.hsl.transitdata</groupId>
     <artifactId>transitdata-tripupdate-processor</artifactId>
-    <version>0.4.4</version>
+    <version>0.4.5</version>
     <packaging>jar</packaging>
 
     <repositories>

--- a/src/main/java/fi/hsl/transitdata/tripupdate/gtfsrt/GtfsRtValidator.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/gtfsrt/GtfsRtValidator.java
@@ -69,7 +69,7 @@ public class GtfsRtValidator {
             // If this is the latest message and it happens to be arrival, we want to use that timestamp.
             // otherwise always use departure.
             OnConflict conflictBehavior = OnConflict.DepartureWins;
-            if (unvalidated == latest && latest.hasArrival()) {
+            if (latest != null && unvalidated == latest && latest.hasArrival()) {
                 conflictBehavior = OnConflict.ArrivalWins;
             }
 


### PR DESCRIPTION
read InternalMessage.cancellation.status and flip the TripUpdate status accordingly. 

tested manually and seems to work. This would definitely require an integration test but atm our develop branch is so ahead of master that it might be a waste of time to do it now.