### PR TITLE
Bug/cancellation tripupdate output

### DIFF
--- a/src/main/java/fi/hsl/transitdata/tripupdate/gtfsrt/GtfsRtFactory.java
+++ b/src/main/java/fi/hsl/transitdata/tripupdate/gtfsrt/GtfsRtFactory.java
@@ -76,6 +76,7 @@ public class GtfsRtFactory {
                 .setDirectionId(direction)
                 .setStartDate(estimate.getTripInfo().getOperatingDay()) // Local date as String
                 .setStartTime(estimate.getTripInfo().getStartTime()) // Local time as String
+                .setScheduleRelationship(GtfsRealtime.TripDescriptor.ScheduleRelationship.SCHEDULED)
                 .build();
 
         GtfsRealtime.TripUpdate.Builder tripUpdateBuilder = GtfsRealtime.TripUpdate.newBuilder()


### PR DESCRIPTION
- cancellation will always be forwarded without estimates
- scheduled (Cancellation of cancellation) will always be forwarded with estimates
- stopestimate will be forwarded if the status is scheduled, but not if the trip is cancelled.
